### PR TITLE
Add multiline option to PlainTextInput

### DIFF
--- a/block_element.go
+++ b/block_element.go
@@ -511,6 +511,8 @@ func NewPlainTextInputBlockElement(placeholder *TextBlockObject, actionID string
 		Type:        METPlainTextInput,
 		ActionID:    actionID,
 		Placeholder: placeholder,
+		Multiline:   false,
+		MinLength:   0,
 	}
 }
 


### PR DESCRIPTION
Adding missing arguments on NewPlainTextInputBlockElement for Multiline and min_length